### PR TITLE
Hypernova/webmon

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,12 @@ FROM debian:trixie-slim
 WORKDIR /work
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends tini bash ca-certificates procps libssl3 \
+ && apt-get install -y --no-install-recommends tini bash ca-certificates procps libssl3 curl \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /src/target/release/xdbg /usr/local/bin/xdbg
 COPY xmtp_debug/newrunner.sh /usr/local/bin/newrunner.sh
-RUN chmod +x /usr/local/bin/xdbg /usr/local/bin/newrunner.sh
+COPY xmtp_debug/web_healthcheck.sh /usr/local/bin/web_healthcheck.sh
+RUN chmod +x /usr/local/bin/xdbg /usr/local/bin/newrunner.sh /usr/local/bin/web_healthcheck.sh
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/newrunner.sh"]

--- a/newrunner.sh
+++ b/newrunner.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: "${XDBG_LOOP_PAUSE:=300}" # default interval between restarts
+: "${MONITOR_LOOP_PAUSE:=300}" # default interval between restarts
 
 function log {
     echo "[$(date '+%F %T')] $*"
@@ -19,23 +19,25 @@ log "WORKSPACE='${WORKSPACE:-<unset>}' -> backend='${BACKEND}'"
 
 while true; do 
   log "Reset environment.."
-  XDBG_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" --clear
-  XDBG_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity identity --amount 5 --concurrency 1
-  XDBG_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity group --amount 1 --concurrency 1 --invite 1
+  MONITOR_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" --clear
+  MONITOR_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity identity --amount 5 --concurrency 1
+  MONITOR_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity group --amount 1 --concurrency 1 --invite 1
   log "Reset complete, starting tests"
   
   for x in {1..10}; {
     log "Identities..."
-    XDBG_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity identity --amount 1 --concurrency 1
+    MONITOR_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity identity --amount 1 --concurrency 1
     log "Sleeping 20s..."
     sleep 20
     log "Groups..."
-    XDBG_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity group --amount 1 --concurrency 1 --invite 1
+    MONITOR_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity group --amount 1 --concurrency 1 --invite 1
     log "Sleeping 20s..."
     sleep 20
     log "Messages..."
-    XDBG_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity message --amount 1 --concurrency 1
-    log "Sleeping $XDBG_LOOP_PAUSE seconds..."
-    sleep $XDBG_LOOP_PAUSE
+    MONITOR_LOOP_PAUSE=0 xdbg -d -b "${BACKEND}" generate --entity message --amount 1 --concurrency 1
+    log "Running health checks..."
+    bash "$(dirname "$0")/web_healthcheck.sh"
+    log "Sleeping $MONITOR_LOOP_PAUSE seconds..."
+    sleep $MONITOR_LOOP_PAUSE
   }
 done

--- a/web_healthcheck.sh
+++ b/web_healthcheck.sh
@@ -45,15 +45,13 @@ for endpoint in "${ENDPOINTS[@]}"; do
     fi
     
     metric_name="web_endpoint_health"
-    timestamp=$(date +%s)
+    timestamp=$(date +%s)000
     
-    metrics_payload=$(cat <<EOF
-# HELP ${metric_name} Health status of web endpoints (1 = healthy, 0 = unhealthy)
+    # Construct payload with explicit newlines
+    metrics_payload="# HELP ${metric_name} Health status of web endpoints (1 = healthy, 0 = unhealthy)
 # TYPE ${metric_name} gauge
-${metric_name}{endpoint="${endpoint}",endpoint_id="${endpoint_id}",http_code="${http_code}"} ${health_status} ${timestamp}000
-
-EOF
-)
+${metric_name}{endpoint=\"${endpoint}\",endpoint_id=\"${endpoint_id}\",http_code=\"${http_code}\"} ${health_status} ${timestamp}
+"
     
     push_url="${PUSHGATEWAY_URL}/metrics/job/web_healthcheck/instance/${endpoint_id}"
     

--- a/web_healthcheck.sh
+++ b/web_healthcheck.sh
@@ -56,24 +56,64 @@ EOF
     
     push_url="${PUSHGATEWAY_URL}/metrics/job/web_healthcheck/instance/${endpoint_id}"
     
-    if curl -s -X POST -H "Content-Type: text/plain" --data-binary "$metrics_payload" "$push_url" > /dev/null 2>&1; then
-        log "Metrics pushed for $endpoint_id"
+    log "DEBUG: About to push to Pushgateway"
+    log "DEBUG: Push URL: $push_url"
+    log "DEBUG: Payload to push:"
+    log "$metrics_payload"
+    
+    # Test if we can reach Pushgateway first
+    log "DEBUG: Testing Pushgateway connectivity..."
+    if curl -s -f "${PUSHGATEWAY_URL}/metrics" > /dev/null 2>&1; then
+        log "DEBUG: Pushgateway is reachable at ${PUSHGATEWAY_URL}"
+    else
+        log "DEBUG: WARNING - Cannot reach Pushgateway at ${PUSHGATEWAY_URL}"
+    fi
+    
+    # Push with full response capture
+    push_response=$(curl -s -w "\nHTTP_CODE:%{http_code}" -X POST -H "Content-Type: text/plain" --data-binary "$metrics_payload" "$push_url" 2>&1)
+    push_exit_code=$?
+    push_http_code=$(echo "$push_response" | grep "HTTP_CODE:" | cut -d: -f2)
+    
+    log "DEBUG: Push exit code: $push_exit_code"
+    log "DEBUG: Push HTTP code: $push_http_code"
+    if [ -n "$push_response" ]; then
+        log "DEBUG: Push response: $push_response"
+    fi
+    
+    if [ $push_exit_code -eq 0 ]; then
+        log "Metrics pushed for $endpoint_id (HTTP $push_http_code)"
+        
+        # Wait a moment for Pushgateway to process
+        sleep 1
         
         # VERIFY: Read back the metric we just pushed
         log "VERIFY: Reading back metrics from Pushgateway..."
-        verification=$(curl -s "${PUSHGATEWAY_URL}/metrics" | grep "web_endpoint_health.*${endpoint_id}")
+        log "VERIFY: Fetching all metrics from ${PUSHGATEWAY_URL}/metrics"
+        
+        all_metrics=$(curl -s "${PUSHGATEWAY_URL}/metrics")
+        verification=$(echo "$all_metrics" | grep "web_endpoint_health.*${endpoint_id}")
+        
         if [ -n "$verification" ]; then
             log "VERIFY SUCCESS: Metric found in Pushgateway:"
             log "$verification"
         else
             log "VERIFY FAILED: Metric NOT found in Pushgateway!"
             log "VERIFY: Checking all web_endpoint_health metrics:"
-            curl -s "${PUSHGATEWAY_URL}/metrics" | grep "web_endpoint_health" | while read -r line; do
+            web_health_metrics=$(echo "$all_metrics" | grep "web_endpoint_health")
+            if [ -n "$web_health_metrics" ]; then
+                echo "$web_health_metrics" | while read -r line; do
+                    log "  $line"
+                done
+            else
+                log "  No web_endpoint_health metrics found at all!"
+            fi
+            log "VERIFY: First 50 lines of all Pushgateway metrics:"
+            echo "$all_metrics" | head -50 | while read -r line; do
                 log "  $line"
             done
         fi
     else
-        log "WARNING: Failed to push metrics for $endpoint_id"
+        log "WARNING: Failed to push metrics for $endpoint_id (exit code: $push_exit_code)"
     fi
 done
 

--- a/web_healthcheck.sh
+++ b/web_healthcheck.sh
@@ -51,6 +51,7 @@ for endpoint in "${ENDPOINTS[@]}"; do
 # HELP ${metric_name} Health status of web endpoints (1 = healthy, 0 = unhealthy)
 # TYPE ${metric_name} gauge
 ${metric_name}{endpoint="${endpoint}",endpoint_id="${endpoint_id}",http_code="${http_code}"} ${health_status} ${timestamp}000
+
 EOF
 )
     

--- a/web_healthcheck.sh
+++ b/web_healthcheck.sh
@@ -58,6 +58,20 @@ EOF
     
     if curl -s -X POST -H "Content-Type: text/plain" --data-binary "$metrics_payload" "$push_url" > /dev/null 2>&1; then
         log "Metrics pushed for $endpoint_id"
+        
+        # VERIFY: Read back the metric we just pushed
+        log "VERIFY: Reading back metrics from Pushgateway..."
+        verification=$(curl -s "${PUSHGATEWAY_URL}/metrics" | grep "web_endpoint_health.*${endpoint_id}")
+        if [ -n "$verification" ]; then
+            log "VERIFY SUCCESS: Metric found in Pushgateway:"
+            log "$verification"
+        else
+            log "VERIFY FAILED: Metric NOT found in Pushgateway!"
+            log "VERIFY: Checking all web_endpoint_health metrics:"
+            curl -s "${PUSHGATEWAY_URL}/metrics" | grep "web_endpoint_health" | while read -r line; do
+                log "  $line"
+            done
+        fi
     else
         log "WARNING: Failed to push metrics for $endpoint_id"
     fi

--- a/web_healthcheck.sh
+++ b/web_healthcheck.sh
@@ -45,12 +45,11 @@ for endpoint in "${ENDPOINTS[@]}"; do
     fi
     
     metric_name="web_endpoint_health"
-    timestamp=$(date +%s)000
     
-    # Construct payload with explicit newlines
+    # Construct payload with explicit newlines (NO timestamp - Pushgateway adds its own)
     metrics_payload="# HELP ${metric_name} Health status of web endpoints (1 = healthy, 0 = unhealthy)
 # TYPE ${metric_name} gauge
-${metric_name}{endpoint=\"${endpoint}\",endpoint_id=\"${endpoint_id}\",http_code=\"${http_code}\"} ${health_status} ${timestamp}
+${metric_name}{endpoint=\"${endpoint}\",endpoint_id=\"${endpoint_id}\",http_code=\"${http_code}\"} ${health_status}
 "
     
     push_url="${PUSHGATEWAY_URL}/metrics/job/web_healthcheck/instance/${endpoint_id}"

--- a/web_healthcheck.sh
+++ b/web_healthcheck.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+
+: "${PUSHGATEWAY_URL:=http://localhost:9091}"
+: "${HEALTHCHECK_TIMEOUT:=10}"
+
+function log {
+    echo "[$(date '+%F %T')] [healthcheck] $*"
+}
+
+if [ -z "${WEB_HEALTHCHECK_ENDPOINTS}" ]; then
+    log "WEB_HEALTHCHECK_ENDPOINTS not set, skipping health checks"
+    exit 0
+fi
+
+IFS=',' read -ra ENDPOINTS <<< "${WEB_HEALTHCHECK_ENDPOINTS}"
+
+if [ ${#ENDPOINTS[@]} -eq 0 ]; then
+    log "No endpoints configured"
+    exit 0
+fi
+
+log "Checking ${#ENDPOINTS[@]} endpoint(s)..."
+
+for endpoint in "${ENDPOINTS[@]}"; do
+    endpoint=$(echo "$endpoint" | xargs)
+    
+    endpoint_id=$(echo "$endpoint" | sed 's|https\?://||' | sed 's|[^a-zA-Z0-9]|_|g')
+    
+    log "Checking endpoint: $endpoint (id: $endpoint_id)"
+    
+    http_code=$(curl -o /dev/null -s -w "%{http_code}" -m "$HEALTHCHECK_TIMEOUT" "$endpoint")
+    curl_exit_code=$?
+    
+    if [ $curl_exit_code -eq 0 ] && [ "$http_code" = "200" ]; then
+        health_status=1
+        log "[OK] $endpoint - OK (200)"
+    else
+        health_status=0
+        if [ $curl_exit_code -ne 0 ]; then
+            log "[FAIL] $endpoint - FAILED (curl error: $curl_exit_code)"
+        else
+            log "[FAIL] $endpoint - FAILED (HTTP $http_code)"
+        fi
+    fi
+    
+    metric_name="web_endpoint_health"
+    timestamp=$(date +%s)
+    
+    metrics_payload=$(cat <<EOF
+# HELP ${metric_name} Health status of web endpoints (1 = healthy, 0 = unhealthy)
+# TYPE ${metric_name} gauge
+${metric_name}{endpoint="${endpoint}",endpoint_id="${endpoint_id}",http_code="${http_code}"} ${health_status} ${timestamp}000
+EOF
+)
+    
+    push_url="${PUSHGATEWAY_URL}/metrics/job/web_healthcheck/instance/${endpoint_id}"
+    
+    if curl -s -X POST -H "Content-Type: text/plain" --data-binary "$metrics_payload" "$push_url" > /dev/null 2>&1; then
+        log "Metrics pushed for $endpoint_id"
+    else
+        log "WARNING: Failed to push metrics for $endpoint_id"
+    fi
+done
+
+log "Health check cycle complete"
+

--- a/web_healthcheck.sh
+++ b/web_healthcheck.sh
@@ -46,7 +46,6 @@ for endpoint in "${ENDPOINTS[@]}"; do
     
     metric_name="web_endpoint_health"
     
-    # Construct payload with explicit newlines (NO timestamp - Pushgateway adds its own)
     metrics_payload="# HELP ${metric_name} Health status of web endpoints (1 = healthy, 0 = unhealthy)
 # TYPE ${metric_name} gauge
 ${metric_name}{endpoint=\"${endpoint}\",endpoint_id=\"${endpoint_id}\",http_code=\"${http_code}\"} ${health_status}
@@ -54,64 +53,18 @@ ${metric_name}{endpoint=\"${endpoint}\",endpoint_id=\"${endpoint_id}\",http_code
     
     push_url="${PUSHGATEWAY_URL}/metrics/job/web_healthcheck/instance/${endpoint_id}"
     
-    log "DEBUG: About to push to Pushgateway"
-    log "DEBUG: Push URL: $push_url"
-    log "DEBUG: Payload to push:"
-    log "$metrics_payload"
-    
-    # Test if we can reach Pushgateway first
-    log "DEBUG: Testing Pushgateway connectivity..."
-    if curl -s -f "${PUSHGATEWAY_URL}/metrics" > /dev/null 2>&1; then
-        log "DEBUG: Pushgateway is reachable at ${PUSHGATEWAY_URL}"
-    else
-        log "DEBUG: WARNING - Cannot reach Pushgateway at ${PUSHGATEWAY_URL}"
-    fi
-    
-    # Push with full response capture
     push_response=$(curl -s -w "\nHTTP_CODE:%{http_code}" -X POST -H "Content-Type: text/plain" --data-binary "$metrics_payload" "$push_url" 2>&1)
     push_exit_code=$?
     push_http_code=$(echo "$push_response" | grep "HTTP_CODE:" | cut -d: -f2)
     
-    log "DEBUG: Push exit code: $push_exit_code"
-    log "DEBUG: Push HTTP code: $push_http_code"
-    if [ -n "$push_response" ]; then
-        log "DEBUG: Push response: $push_response"
-    fi
-    
-    if [ $push_exit_code -eq 0 ]; then
-        log "Metrics pushed for $endpoint_id (HTTP $push_http_code)"
-        
-        # Wait a moment for Pushgateway to process
-        sleep 1
-        
-        # VERIFY: Read back the metric we just pushed
-        log "VERIFY: Reading back metrics from Pushgateway..."
-        log "VERIFY: Fetching all metrics from ${PUSHGATEWAY_URL}/metrics"
-        
-        all_metrics=$(curl -s "${PUSHGATEWAY_URL}/metrics")
-        verification=$(echo "$all_metrics" | grep "web_endpoint_health.*${endpoint_id}")
-        
-        if [ -n "$verification" ]; then
-            log "VERIFY SUCCESS: Metric found in Pushgateway:"
-            log "$verification"
-        else
-            log "VERIFY FAILED: Metric NOT found in Pushgateway!"
-            log "VERIFY: Checking all web_endpoint_health metrics:"
-            web_health_metrics=$(echo "$all_metrics" | grep "web_endpoint_health")
-            if [ -n "$web_health_metrics" ]; then
-                echo "$web_health_metrics" | while read -r line; do
-                    log "  $line"
-                done
-            else
-                log "  No web_endpoint_health metrics found at all!"
-            fi
-            log "VERIFY: First 50 lines of all Pushgateway metrics:"
-            echo "$all_metrics" | head -50 | while read -r line; do
-                log "  $line"
-            done
-        fi
+    if [ $push_exit_code -eq 0 ] && [ "$push_http_code" = "200" ]; then
+        log "Metrics pushed for $endpoint_id"
     else
-        log "WARNING: Failed to push metrics for $endpoint_id (exit code: $push_exit_code)"
+        log "ERROR: Failed to push metrics for $endpoint_id (HTTP $push_http_code, exit code: $push_exit_code)"
+        error_message=$(echo "$push_response" | grep -v "HTTP_CODE:")
+        if [ -n "$error_message" ]; then
+            log "ERROR: $error_message"
+        fi
     fi
 done
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add web health check metrics to Hypernova/webmon by installing `curl`, copying `web_healthcheck.sh` to `/usr/local/bin/web_healthcheck.sh`, and invoking it each loop in `newrunner.sh` with `MONITOR_LOOP_PAUSE` control
Introduce a `web_healthcheck.sh` script that runs `curl` checks on configured endpoints and pushes Prometheus metrics, add `curl` to the runtime image, and switch loop control to `MONITOR_LOOP_PAUSE` in [docker/Dockerfile](https://github.com/xmtp/protocol-e2e-tests/pull/4/files#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddc) and [xmtp_debug/newrunner.sh](https://github.com/xmtp/protocol-e2e-tests/pull/4/files#diff-77b9d99b1ee45e12cff1788d7fd52026079a65c492492cddb9f46b10d1482abc).

#### 📍Where to Start
Start with the health check flow in [xmtp_debug/web_healthcheck.sh](https://github.com/xmtp/protocol-e2e-tests/pull/4/files#diff-3d3dac341f46cf1e90323c6adcc5c298316f4e9abadf502bc657ae6db5508f91), then review its invocation inside the loop in [xmtp_debug/newrunner.sh](https://github.com/xmtp/protocol-e2e-tests/pull/4/files#diff-77b9d99b1ee45e12cff1788d7fd52026079a65c492492cddb9f46b10d1482abc).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f89c4e3. 2 files reviewed, 9 issues evaluated, 5 issues filtered, 3 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>newrunner.sh — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 3](https://github.com/xmtp/protocol-e2e-tests/blob/f89c4e36e0d85974f26079b976db1fa509344cf9/newrunner.sh#L3): Contract/regression: the environment variable controlling loop pauses was renamed from `XDBG_LOOP_PAUSE` to `MONITOR_LOOP_PAUSE` (line 3) and the child-process overrides were changed accordingly at lines 22, 23, 24, 29, 33, and 37. If callers or the `xdbg` tool expect `XDBG_LOOP_PAUSE`, the new script will ignore that input and `xdbg` may also ignore the `MONITOR_LOOP_PAUSE` override, changing behavior (e.g., failing to suppress internal pauses). The visible contract for controlling pause duration and the per-command override has changed without guard or compatibility. <b>[ Low confidence ]</b>
- [line 22](https://github.com/xmtp/protocol-e2e-tests/blob/f89c4e36e0d85974f26079b976db1fa509344cf9/newrunner.sh#L22): No error handling for external commands: all `xdbg` invocations (lines 22–25, 29, 33, 37) and the health check `bash "$(dirname "$0")/web_healthcheck.sh"` (line 39) are executed without checking exit status. Failures silently proceed to subsequent steps, potentially leaving the environment partially reset or tests running against a bad state. Use guards such as `set -e`, `|| exit`, or `&&` chaining to ensure a defined terminal outcome on failure. <b>[ Low confidence ]</b>
</details>

<details>
<summary>web_healthcheck.sh — 3 comments posted, 6 evaluated, 3 filtered</summary>

- [line 35](https://github.com/xmtp/protocol-e2e-tests/blob/f89c4e36e0d85974f26079b976db1fa509344cf9/web_healthcheck.sh#L35): Health status treats only HTTP `200` as success. Healthy endpoints frequently return other 2xx codes (e.g., `204`), or require following redirects (e.g., `301/302`). Without `-L`, many endpoints will be marked unhealthy despite being reachable. Consider treating any 2xx as healthy and using `curl -L` when appropriate or making this configurable. <b>[ Low confidence ]</b>
- [line 54](https://github.com/xmtp/protocol-e2e-tests/blob/f89c4e36e0d85974f26079b976db1fa509344cf9/web_healthcheck.sh#L54): `PUSHGATEWAY_URL` is not validated. If empty or malformed, `push_url` becomes invalid (e.g., starting with `/metrics/...`), and `curl` will fail or target a local file path. Add a guard to ensure `PUSHGATEWAY_URL` is a non-empty valid URL before pushing metrics. <b>[ Low confidence ]</b>
- [line 58](https://github.com/xmtp/protocol-e2e-tests/blob/f89c4e36e0d85974f26079b976db1fa509344cf9/web_healthcheck.sh#L58): `push_http_code` extraction is fragile: `grep "HTTP_CODE:" | cut -d: -f2` will return multiple lines if the response body contains `HTTP_CODE:` anywhere, causing ambiguous comparison and potential false negatives in success detection. Safer to read only the last line or use `tail -n1` to select the appended status line. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->